### PR TITLE
Add Copious Notes developer blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -9,6 +9,13 @@
         "description": "Whether it’s an official Apple blog, or a community blog that keeps us up to date with what’s going on with the platform it’ll be here.",
         "sites": [
           {
+            "title": "Copious Notes",
+            "author": "Mark Townsend",
+            "site_url": "https://www.markltownsend.com",
+            "feed_url": "https://www.markltownsend.com/feed.xml",
+            "mastodon_url": "https://iosdev.space/@markltownsend"
+          },
+          {
             "title": "App Store Review Guidelines History",
             "author": "The Shape Team",
             "site_url": "http://www.appstorereviewguidelineshistory.com/",


### PR DESCRIPTION
Adding in my new developer blog, Copious Notes.  The `feed.xml` isn't working for some reason, I'm looking into it.